### PR TITLE
Set module user to 'gdsoperations'

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "puppet-unattended_reboot",
+  "name": "gdsoperations-unattended_reboot",
   "version": "0.1.0",
   "author": "Government Digital Service",
   "summary": "Coordinates unattended reboots of Ubuntu servers",


### PR DESCRIPTION
Without this, the Puppet Forge refuses to publish the module as it
thinks we're trying to publish under the user 'puppet' rather than
'gdsoperations'.

This is also required to comply with Puppet's convention of prefixing
the module name with the username of the user that publishes the module.
