### PR TITLE
Tighten up stdlib dependency.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 3.0.0 <5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The currently specified version is very out of date and doesn't reflect
the versions of puppet we use. The new range does.
