### PR TITLE
Ensure run-parts executes scripts with extensions and release version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0 (2016-02-25)
+ 
+  - Bug fix: Ensure run-parts will execute scripts with file extensions
+
 ## 0.1.0 (2015-06-18)
  
   - Initial release

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "gdsoperations-unattended_reboot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Government Digital Service",
   "summary": "Coordinates unattended reboots of Ubuntu servers",
   "license": "MIT",

--- a/spec/classes/unattended_reboot_spec.rb
+++ b/spec/classes/unattended_reboot_spec.rb
@@ -75,12 +75,12 @@ describe 'unattended_reboot', :type => :class do
         :check_scripts_directory => '/path',
       })}
 
-      it { should contain_file('/usr/local/bin/unattended-reboot').with_content(/^\/bin\/run-parts --exit-on-error \/path$/) }
+      it { should contain_file('/usr/local/bin/unattended-reboot').with_content(/^\/bin\/run-parts --regex '.*' --exit-on-error \/path$/) }
     end
 
     context "check_scripts_directory not set" do
       it { should_not raise_error }
-      it { should contain_file('/usr/local/bin/unattended-reboot').without_content(/^\/bin\/run-parts --exit-on-error\s*$/) }
+      it { should contain_file('/usr/local/bin/unattended-reboot').without_content(/^\/bin\/run-parts --regex '.*' --exit-on-error\s*$/) }
     end
 
     context "check_scripts_directory set to non-absolute path" do
@@ -96,12 +96,12 @@ describe 'unattended_reboot', :type => :class do
         :pre_reboot_scripts_directory => '/path',
       })}
 
-      it { should contain_file('/usr/local/bin/unattended-reboot').with_content(/^\/bin\/run-parts --exit-on-error \/path$/) }
+      it { should contain_file('/usr/local/bin/unattended-reboot').with_content(/^\/bin\/run-parts --regex '.*' --exit-on-error \/path$/) }
     end
 
     context "pre_reboot_scripts_directory not set" do
       it { should_not raise_error }
-      it { should contain_file('/usr/local/bin/unattended-reboot').without_content(/^\/bin\/run-parts --exit-on-error\s*$/) }
+      it { should contain_file('/usr/local/bin/unattended-reboot').without_content(/^\/bin\/run-parts --regex '.*' --exit-on-error\s*$/) }
     end
 
     context "pre_reboot_scripts_directory set to non-absolute path" do

--- a/templates/unattended-reboot.erb
+++ b/templates/unattended-reboot.erb
@@ -15,7 +15,7 @@ if ! [ -f /var/run/reboot-required ]; then
 fi
 
 <% unless @check_scripts_directory == '' -%>
-/bin/run-parts --exit-on-error <%= @check_scripts_directory %>
+/bin/run-parts --regex '.*' --exit-on-error <%= @check_scripts_directory %>
 
 if [ $? -ne 0 ]; then
   echo 'One of the check scripts returned a non-zero exit code' >&2
@@ -31,7 +31,7 @@ if [ $? -ne 0 ]; then
 fi
 
 <% unless @pre_reboot_scripts_directory == '' -%>
-/bin/run-parts --exit-on-error <%= @pre_reboot_scripts_directory %>
+/bin/run-parts --regex '.*' --exit-on-error <%= @pre_reboot_scripts_directory %>
 
 if [ $? -ne 0 ]; then
   echo 'One of the pre-reboot scripts returned a non-zero exit code' >&2


### PR DESCRIPTION
Without passing a regex to `run-parts`, it will not execute scripts with
a file extension, e.g. `.py`.

This is surprising, although documented, behaviour, so set a regex so
that we don't reboot unexpectedly if a script in
`@check_scripts_directory` is not executed.

This behaviour is documented: http://manpages.ubuntu.com/manpages/dapper/man8/run-parts.8.html

> If the --lsbsysinit option is not given then the names must consist
> entirely of upper and lower case letters, digits, underscores, and
> hyphens.

Ubuntu bug: https://bugs.launchpad.net/ubuntu/+source/debianutils/+bug/38022

The upstream Debian bug has been archived:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=472585
