### PR TITLE
Move crontab to etc.d. Bump version to 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,15 @@ bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 rvm:
   - 1.9.3
-  - 2.0.0
   - 2.1.0
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 3.8.0"
+  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 4.9.0"
 matrix:
-  exclude:
-  # Ruby 2.1.0
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0"
+  allow_failures:
+    - env: PUPPET_VERSION="~> 4.9.0"
+      rvm: 1.9.3
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
+gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.0'
 
 gem 'rake'
 gem 'puppet-lint'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,7 +100,6 @@ class unattended_reboot (
 
   if ($enabled) {
     $cron_ensure = present
-    $directory_ensure = directory
     $file_ensure = present
     $pkg_ensure = latest
 
@@ -115,7 +114,6 @@ class unattended_reboot (
     }
   } else {
     $cron_ensure = absent
-    $directory_ensure = absent
     $file_ensure = absent
     $pkg_ensure  = purged
     $unattended_upgrade_cron_ensure = absent

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,32 +144,29 @@ class unattended_reboot (
     content => template('unattended_reboot/unattended-reboot.erb'),
   } ->
   # Check if a reboot is required and attempt to grab the reboot mutex.
-  cron { 'unattended-reboot':
+  unattended_reboot::root_crontab { 'unattended-reboot':
     ensure      => $cron_ensure,
     month       => $cron_month,
     monthday    => $cron_monthday,
     weekday     => $cron_weekday,
     hour        => $cron_hour,
     minute      => $cron_minute,
-    user        => 'root',
+    require     => Package['update-notifier-common'],
     environment => $cron_env_vars,
     command     => '/usr/local/bin/unattended-reboot',
-    require     => Package['update-notifier-common'],
   }
 
   # Run unattended upgrade to maximise the chance that an upgraded package is
   # installed within the reboot window
-  cron { 'unattended-upgrade':
+  unattended_reboot::root_crontab { 'unattended-upgrade':
     ensure      => $unattended_upgrade_cron_ensure,
     month       => $cron_month,
     monthday    => $cron_monthday,
     weekday     => $cron_weekday,
     hour        => $cron_hour,
     minute      => fqdn_rand(59),
-    user        => 'root',
+    require     => Package['unattended-upgrades'],
     environment => $cron_env_vars,
     command     => '/usr/bin/unattended-upgrade',
-    require     => Package['unattended-upgrades'],
   }
-
 }

--- a/manifests/root_crontab.pp
+++ b/manifests/root_crontab.pp
@@ -1,0 +1,64 @@
+# == Type: root_crontab
+#
+# Create a cron script /etc/cron.d/$title that runs as root.
+#
+# === Parameters
+# [*ensure*]
+#   Whether to create the cron.d file
+#   Default: absent
+#
+# [*command*]
+#   Command to be run by cron.
+#   Default: ''
+#
+# [*environment*]
+#   An array of environment variables to apply to the created cronjobs.
+#   Default: []
+#
+# [*month*]
+#   Month of year at which to run the cron job.
+#   Default: '*'
+#
+# [*monthday*]
+#   Day of month at which to run the cron job.
+#   Default: '*'
+#
+# [*weekday*]
+#   Day of week at which to run the cron job.
+#   Default: '*'
+#
+# [*hour*]
+#   Hour of the day at which to run the cron job.
+#   Default: '0-5'
+#
+# [*minute*]
+#   Minute of the hour at which to run the cron job.
+#   Default: '*/5'
+#
+define unattended_reboot::root_crontab (
+  $ensure = absent,
+  $month = '*',
+  $monthday = '*',
+  $weekday = '*',
+  $hour = '0-7',
+  $minute = '*/5',
+  $command = '',
+  $environment = [],
+) {
+  $full_path = "/etc/cron.d/${title}"
+  if ($ensure == present or $ensure == file) {
+    validate_array($environment)
+
+    file { $full_path:
+      ensure  => file,
+      mode    => '0755',
+      owner   => 'root',
+      group   => 'root',
+      content => template('unattended_reboot/crontab.erb'),
+    }
+  } else {
+    file { $full_path:
+      ensure => absent,
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "gdsoperations-unattended_reboot",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Government Digital Service",
   "summary": "Coordinates unattended reboots of Ubuntu servers",
   "license": "MIT",

--- a/spec/classes/unattended_reboot_spec.rb
+++ b/spec/classes/unattended_reboot_spec.rb
@@ -16,7 +16,7 @@ describe 'unattended_reboot', :type => :class do
     it { should contain_file('/etc/init/post-reboot-unlock.conf').with_ensure('present') }
     it { should contain_file('/usr/local/bin/unattended-reboot').with_ensure('present') }
 
-    it { should contain_cron('unattended-reboot').with_ensure('present') }
+    it { should contain_unattended_reboot__root_crontab('unattended-reboot').with_ensure('present') }
 
     it "passes all endpoints to locksmithctl" do
       should contain_file('/usr/local/bin/unattended-reboot').with_content(/locksmithctl -endpoint='http:\/\/etcd-1\.foo:4001,http:\/\/etcd-2\.foo:4001' lock/)
@@ -51,7 +51,7 @@ describe 'unattended_reboot', :type => :class do
         :run_unattended_upgrade => true,
       })}
 
-      it { should contain_cron('unattended-upgrade').with_ensure('present') }
+      it { should contain_unattended_reboot__root_crontab('unattended-upgrade').with_ensure('present') }
     end
 
     context "run_unattended_upgrade is false" do
@@ -59,7 +59,7 @@ describe 'unattended_reboot', :type => :class do
         :run_unattended_upgrade => false,
       })}
 
-      it { should contain_cron('unattended-upgrade').with_ensure('absent') }
+      it { should contain_unattended_reboot__root_crontab('unattended-upgrade').with_ensure('absent') }
     end
 
     context "empty array passed to etcd_endpoints" do
@@ -121,8 +121,8 @@ describe 'unattended_reboot', :type => :class do
     it { should contain_file('/etc/init/post-reboot-unlock.conf').with_ensure('absent') }
     it { should contain_file('/usr/local/bin/unattended-reboot').with_ensure('absent') }
 
-    it { should contain_cron('unattended-reboot').with_ensure('absent') }
-    it { should contain_cron('unattended-upgrade').with_ensure('absent') }
+    it { should contain_unattended_reboot__root_crontab('unattended-reboot').with_ensure('absent') }
+    it { should contain_unattended_reboot__root_crontab('unattended-upgrade').with_ensure('absent') }
 
     context "disabled and empty array passed to etcd_endpoints" do
       let(:params) {{

--- a/spec/defines/root_crontab_spec.rb
+++ b/spec/defines/root_crontab_spec.rb
@@ -1,0 +1,37 @@
+require_relative '../spec_helper'
+
+describe 'unattended_reboot::root_crontab', :type => :define do
+  let(:title) { 'crontest' }
+    let(:default_params) {{
+      :ensure => 'present',
+      :command => 'testCmd',
+    }}
+
+  context 'present' do
+    let(:params) { default_params }
+    it { should contain_file('/etc/cron.d/crontest').with_ensure('file') }
+    it { should contain_file('/etc/cron.d/crontest').with_content(/\*\/5 0-7 \* \* \* root testCmd/) }
+
+    context 'environment variables set' do
+      let(:params) { default_params.merge({ :environment => ['ONE=1', 'TWO=2'], }) }
+      it { should contain_file('/etc/cron.d/crontest').with_content(/ONE=1\nTWO=2\n\*\/5 0-7 \* \* \* root testCmd/m) }
+    end
+  end
+
+  context 'file' do
+    let(:params) { default_params.merge({ :ensure => 'file', }) }
+    it { should contain_file('/etc/cron.d/crontest').with_ensure('file') }
+    it { should contain_file('/etc/cron.d/crontest').with_content(/\*\/5 0-7 \* \* \* root testCmd/) }
+  end
+
+  context 'defaults' do
+    let(:params) { {} }
+    it { should contain_file('/etc/cron.d/crontest').with_ensure('absent') }
+  end
+
+  context 'absent' do
+    let(:params) { default_params.merge({ :ensure => 'absent', }) }
+
+    it { should contain_file('/etc/cron.d/crontest').with_ensure('absent') }
+  end
+end

--- a/templates/crontab.erb
+++ b/templates/crontab.erb
@@ -1,0 +1,6 @@
+<% if !@environment.empty? -%>
+<% for env in @environment -%>
+<%= env %>
+<% end -%>
+<% end -%>
+<%= @minute %> <%= @hour %> <%= @monthday %> <%= @month %> <%= @weekday %> root <%= @command %>


### PR DESCRIPTION
Rather than use the default root crontab this moves cron jobs to their own files in cron.d. This helps prevent sharing of environment variables like MAILTO with other jobs where they may conflict.