### PR TITLE
Add basis for functional tests.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+#^syntax detection
+
+forge "https://forgeapi.puppetlabs.com"
+
+# use dependencies defined in metadata.json
+#metadata
+
+mod 'puppetlabs-stdlib'

--- a/site.pp
+++ b/site.pp
@@ -1,0 +1,3 @@
+class { 'unattended_reboot':
+  enabled => true,
+}

--- a/test/integration/default/packages_spec.rb
+++ b/test/integration/default/packages_spec.rb
@@ -1,0 +1,7 @@
+%w[update-notifier-common unattended-upgrades].each do |pkg|
+
+  describe package(pkg) do
+    it { should be_installed }
+  end
+
+end


### PR DESCRIPTION
These are the supporting files needed to make the basic package tests run
under docker test kitchen