### PR TITLE
Don't run tests against Ruby 1.9.3 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ script: bundle exec rake test
 matrix:
   fast_finish: true
   include:
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 3.8.0"
     - rvm: 2.4.0
       env: PUPPET_VERSION="~> 5.3.0"
   allow_failures:


### PR DESCRIPTION
- Ruby 1.9.3 doesn't exist in Travis CI any more, so whenever tests run,
  they go red.
- This means that whoever last merged a PR gets emails every week when
  Travis tries to rerun the tests for the master build -
  https://travis-ci.org/gds-operations/puppet-unattended_reboot/builds.
  It's noisy and there's nothing we can do.